### PR TITLE
Fixing end closure in unminified script

### DIFF
--- a/jl-tether.js
+++ b/jl-tether.js
@@ -1562,4 +1562,4 @@ return /******/ (function(modules) { // webpackBootstrap
 
 /***/ }
 /******/ ])
-})
+});


### PR DESCRIPTION
I'm currently concatenating this (unminified, `jl-tether.js`) with Gulp, and it's causing the library after it to fatal. I suspect that the closure is executing the next library, so adding a semicolon fixes the issue.

Thanks for your hard work!